### PR TITLE
Zac new samples

### DIFF
--- a/components/landing/tabs.tsx
+++ b/components/landing/tabs.tsx
@@ -12,7 +12,7 @@ import completeCode from "@/lib/code-complete";
 export const TabSection = () => {
     return (
         <div id='tabsSection'>
-            <h1 className='mt-2 text-center font-semibold italic text-green-500'>
+            <h1 className='mt-2 flex items-center justify-center text-center font-semibold italic text-green-500'>
                 🔈 Tailspin is still in development! Click on the face{" "}
                 <FeedbackModal /> and help make Tailspin great!
             </h1>
@@ -52,7 +52,9 @@ export const TabSection = () => {
                     <TabsContent value='image' className='h-[90vh]'>
                         <BrowserMockup>
                             <StaticPrompt
-                                code={completeCode(LandingPageChallengeCode())}
+                                code={completeCode(
+                                    LandingPageChallengeCode("helloWorld")
+                                )}
                             />
                         </BrowserMockup>
                     </TabsContent>

--- a/components/landing/test-challenges/challenge-code.ts
+++ b/components/landing/test-challenges/challenge-code.ts
@@ -13,7 +13,7 @@ export default function LandingPageChallengeCode(codeKey: CodeKey): string {
         ["brightSunnyDay", BrightSunnyDay],
     ]);
     const func = landingPageCodeMap.get(codeKey)!;
-    return func();
+    return func ? func() : "";
 }
 
 function ButtonHelloWorld(): string {

--- a/components/landing/test-challenges/challenge-code.ts
+++ b/components/landing/test-challenges/challenge-code.ts
@@ -1,5 +1,56 @@
-export default function LandingPageChallengeCode() {
+type CodeKey =
+    | "helloWorld"
+    | "simpleDialog"
+    | "simpleNavBar"
+    | "brightSunnyDay";
+
+export default function LandingPageChallengeCode(codeKey: CodeKey): string {
+    type FunctionType = () => string;
+    const landingPageCodeMap: Map<CodeKey, FunctionType> = new Map([
+        ["helloWorld", ButtonHelloWorld],
+        ["simpleDialog", SimpleDialog],
+        ["simpleNavBar", SimpleNavBar],
+        ["brightSunnyDay", BrightSunnyDay],
+    ]);
+    const func = landingPageCodeMap.get(codeKey)!;
+    return func();
+}
+
+function ButtonHelloWorld(): string {
     return `<button class="bg-blue-500 text-white rounded-full p-2">
             Hello World
         </button>`;
+}
+
+function SimpleDialog(): string {
+    return `<div class="flex items-center justify-center h-screen">
+    <div class="bg-black text-white rounded-lg shadow-md w-96 p-6">
+      <h2 class="text-xl font-semibold mb-4">Dialog</h2>
+      <p class="text-white mb-4">For this exercise, do not implement any event
+        listeners and such.</p>
+    </div>
+  </div>`;
+}
+
+function SimpleNavBar(): string {
+    return `<nav class="bg-white shadow p-4">
+    <div class="container mx-auto">
+      <ul class="flex space-x-6">
+        <li><a href="#" class="text-gray-700 hover:text-blue-600">Home</a></li>
+        <li><a href="#" class="text-gray-700 hover:text-blue-600">About</a></li>
+        <li><a href="#" class="text-gray-700 hover:text-blue-600">Contact</a></li>
+        <li><a href="#" class="text-gray-700 hover:text-blue-600">[Hint: All text
+            are gray-700 and blue-600 on hover, including this one]</a></li>
+      </ul>
+    </div>
+  </nav>`;
+}
+
+function BrightSunnyDay(): string {
+    return `<div class="min-h-screen flex items-center justify-center bg-blue-300">
+    <div class="bg-yellow-300 w-32 h-32 rounded-full flex items-center justify-center">
+      <p class="text-center">bright sunny day</p>
+    </div>
+    </div>
+`;
 }

--- a/components/landing/test-challenges/challenge-image.ts
+++ b/components/landing/test-challenges/challenge-image.ts
@@ -1,3 +1,0 @@
-export default function ChallengeImagePath() {
-    return "./button.png";
-}


### PR DESCRIPTION
- Refactored the `LandingPageChallengeCode()` function to take in a type safe string for returning challenge codes
- Made the email support become 1 line instead of 2 by adding a flex box

closes #6 